### PR TITLE
added sixlowpan fragmentation benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,9 @@ required-features = ["std", "medium-ethernet", "medium-ip", "phy-tuntap_interfac
 [[example]]
 name = "sixlowpan"
 required-features = ["std", "medium-ieee802154", "phy-raw_socket", "proto-sixlowpan", "socket-udp"]
+[[example]]
+name = "sixlowpan_benchmark"
+required-features = ["std", "medium-ieee802154", "phy-raw_socket", "proto-sixlowpan", "socket-udp"]
 
 [profile.release]
 debug = 2

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -81,8 +81,6 @@ fn main() {
         _ => panic!("invalid mode"),
     };
 
-    
-
     let neighbor_cache = NeighborCache::new(BTreeMap::new());
 
     let tcp1_rx_buffer = TcpSocketBuffer::new(vec![0; 65535]);

--- a/examples/sixlowpan_benchmark.rs
+++ b/examples/sixlowpan_benchmark.rs
@@ -65,8 +65,8 @@ use std::thread;
 use std::fs;
 
 fn if_nametoindex(ifname: &str) -> u32 {
-    let contents = fs::read_to_string(format!("/sys/devices/virtual/net/{}/ifindex",ifname))
-        .expect(format!("Something went wrong trying to get IF-index of lowpan0, does \"/sys/devices/virtual/net/{}/ifindex\" exist?", ifname).as_str())
+    let contents = fs::read_to_string(format!("/sys/devices/virtual/net/{}/ifindex", ifname))
+        .expect("couldn't read interface from \"/sys/devices/virtual/net")
         .replace("\n", "");
     contents.parse::<u32>().unwrap()
 }

--- a/examples/sixlowpan_benchmark.rs
+++ b/examples/sixlowpan_benchmark.rs
@@ -1,35 +1,104 @@
-#![allow(clippy::collapsible_if)]
+//! 6lowpan benchmark exmaple
+//!
+//! This example is designed to run using the Linux ieee802154/6lowpan support,
+//! using mac802154_hwsim.
+//!
+//! mac802154_hwsim allows you to create multiple "virtual" radios and specify
+//! which is in range with which. This is very useful for testing without
+//! needing real hardware. By default it creates two interfaces `wpan0` and
+//! `wpan1` that are in range with each other. You can customize this with
+//! the `wpan-hwsim` tool.
+//!
+//! We'll configure Linux to speak 6lowpan on `wpan0`, and leave `wpan1`
+//! unconfigured so smoltcp can use it with a raw socket.
+//!
+//! # Setup
+//!
+//!     modprobe mac802154_hwsim
+//!
+//!     ip link set wpan0 down
+//!     ip link set wpan1 down
+//!     iwpan dev wpan0 set pan_id 0xbeef
+//!     iwpan dev wpan1 set pan_id 0xbeef
+//!     ip link add link wpan0 name lowpan0 type lowpan
+//!     ip link set wpan0 up
+//!     ip link set wpan1 up
+//!     ip link set lowpan0 up
+//!
+//! # Running
+//!
+//! Run it with `sudo ./target/debug/examples/sixlowpan`.
+//!
+//! You can set wireshark to sniff on interface `wpan0` to see the packets.
+//!
+//! Ping it with `ping fe80::180b:4242:4242:4242%lowpan0`.
+//!
+//! Speak UDP with `nc -uv fe80::180b:4242:4242:4242%lowpan0 6969`.
+//!
+//! # Teardown
+//!
+//!     rmmod mac802154_hwsim
+//!
 
 mod utils;
 
 use log::debug;
-use std::cmp;
 use std::collections::BTreeMap;
-use std::io::{Read, Write};
-use std::net::TcpStream;
 use std::os::unix::io::AsRawFd;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::thread;
+use std::str;
 
-use smoltcp::iface::{InterfaceBuilder, NeighborCache};
-use smoltcp::phy::{wait as phy_wait, Device, Medium};
+use smoltcp::iface::{FragmentsCache, InterfaceBuilder, NeighborCache};
+use smoltcp::phy::{wait as phy_wait, Medium, RawSocket};
 use smoltcp::socket::{TcpSocket, TcpSocketBuffer};
-use smoltcp::time::{Duration, Instant};
-use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr};
+use smoltcp::storage::RingBuffer;
+use smoltcp::wire::{Ieee802154Pan, IpAddress, IpCidr};
 
-const AMOUNT: usize = 1_000_000_000;
+
+
+//For benchmark
+use smoltcp::time::{Duration, Instant};
+use std::thread;
+use std::cmp;
+use std::net::TcpStream;
+use std::net::{SocketAddrV6};
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+
+
+use std::fs;
+
+
+fn if_nametoindex(ifname: &str) -> u32 {
+    let contents = fs::read_to_string(format!("/sys/devices/virtual/net/{}/ifindex",ifname))
+        .expect(format!("Something went wrong trying to get IF-index of lowpan0, does \"/sys/devices/virtual/net/{}/ifindex\" exist?", ifname).as_str())
+        .replace("\n", "");
+    contents.parse::<u32>().unwrap()
+
+}
+
+const AMOUNT: usize = 100_000_000;
 
 enum Client {
     Reader,
     Writer,
 }
 
-fn client(kind: Client) {
-    let port = match kind {
+
+fn client(kind: Client){
+    let port: u16 = match kind {
         Client::Reader => 1234,
         Client::Writer => 1235,
     };
-    let mut stream = TcpStream::connect(("192.168.69.1", port)).unwrap();
+
+    let scope_id = if_nametoindex("lowpan0");
+
+    let socket_addr = SocketAddrV6::new("fe80:0:0:0:180b:4242:4242:4242".parse().unwrap(), port, 0, scope_id);
+    
+    //let socket_addr: SocketAddrV6 = "[fe80:0:0:0:180b:4242:4242:4242]:1234".parse().unwrap();
+
+
+    let mut stream = TcpStream::connect(socket_addr).expect("failed to connect TLKAGMKA");
     let mut buffer = vec![0; 1_000_000];
 
     let start = Instant::now();
@@ -60,56 +129,80 @@ fn client(kind: Client) {
     CLIENT_DONE.store(true, Ordering::SeqCst);
 }
 
+
 static CLIENT_DONE: AtomicBool = AtomicBool::new(false);
 
-fn main() {
+fn main(){
     #[cfg(feature = "log")]
     utils::setup_logging("info");
 
     let (mut opts, mut free) = utils::create_options();
-    utils::add_tuntap_options(&mut opts, &mut free);
     utils::add_middleware_options(&mut opts, &mut free);
     free.push("MODE");
 
+
     let mut matches = utils::parse_options(&opts, free);
-    let device = utils::parse_tuntap_options(&mut matches);
+
+    let device = RawSocket::new("wpan1", Medium::Ieee802154).unwrap();
+
     let fd = device.as_raw_fd();
     let device = utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
+
+
     let mode = match matches.free[0].as_ref() {
         "reader" => Client::Reader,
         "writer" => Client::Writer,
         _ => panic!("invalid mode"),
     };
 
-    
-
     let neighbor_cache = NeighborCache::new(BTreeMap::new());
 
-    let tcp1_rx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
-    let tcp1_tx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
+    let tcp1_rx_buffer = TcpSocketBuffer::new(vec![0; 4096]);
+    let tcp1_tx_buffer = TcpSocketBuffer::new(vec![0; 4096]);
     let tcp1_socket = TcpSocket::new(tcp1_rx_buffer, tcp1_tx_buffer);
 
-    let tcp2_rx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
-    let tcp2_tx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
+    let tcp2_rx_buffer = TcpSocketBuffer::new(vec![0; 4096]);
+    let tcp2_tx_buffer = TcpSocketBuffer::new(vec![0; 4096]);
     let tcp2_socket = TcpSocket::new(tcp2_rx_buffer, tcp2_tx_buffer);
 
-    let ethernet_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
-    let ip_addrs = [IpCidr::new(IpAddress::v4(192, 168, 69, 1), 24)];
-    let medium = device.capabilities().medium;
-    let mut builder = InterfaceBuilder::new(device, vec![]).ip_addrs(ip_addrs);
-    if medium == Medium::Ethernet {
-        builder = builder
-            .hardware_addr(ethernet_addr.into())
-            .neighbor_cache(neighbor_cache);
-    }
+    let ieee802154_addr = smoltcp::wire::Ieee802154Address::Extended([
+        0x1a, 0x0b, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+    ]);
+    let ip_addrs = [IpCidr::new(
+        IpAddress::v6(0xfe80, 0, 0, 0, 0x180b, 0x4242, 0x4242, 0x4242),
+        64,
+    )];
+
+    let cache = FragmentsCache::new(vec![], BTreeMap::new());
+
+    let buffer: Vec<(usize, managed::ManagedSlice<'_, u8>)> = (0..12)
+        .into_iter()
+        .map(|_| (0_usize, managed::ManagedSlice::from(vec![0; 1_000_000_000])))
+        .collect();
+
+    let out_fragments_cache = RingBuffer::new(buffer);
+
+    let mut builder = InterfaceBuilder::new(device, vec![])
+        .ip_addrs(ip_addrs)
+        .pan_id(Ieee802154Pan(0xbeef));
+    builder = builder
+        .hardware_addr(ieee802154_addr.into())
+        .neighbor_cache(neighbor_cache)
+        .sixlowpan_fragments_cache(cache)
+        .out_fragments_cache(out_fragments_cache);
     let mut iface = builder.finalize();
 
     let tcp1_handle = iface.add_socket(tcp1_socket);
     let tcp2_handle = iface.add_socket(tcp2_socket);
+
+
+
     let default_timeout = Some(Duration::from_millis(1000));
+    
 
     thread::spawn(move || client(mode));
     let mut processed = 0;
+
     while !CLIENT_DONE.load(Ordering::SeqCst) {
         let timestamp = Instant::now();
         match iface.poll(timestamp) {

--- a/examples/sixlowpan_benchmark.rs
+++ b/examples/sixlowpan_benchmark.rs
@@ -209,16 +209,14 @@ fn main() {
             socket.listen(1234).unwrap();
         }
 
-        if socket.can_send() {
-            if processed < AMOUNT {
-                let length = socket
-                    .send(|buffer| {
-                        let length = cmp::min(buffer.len(), AMOUNT - processed);
-                        (length, length)
-                    })
-                    .unwrap();
-                processed += length;
-            }
+        if socket.can_send() && processed < AMOUNT {
+            let length = socket
+                .send(|buffer| {
+                    let length = cmp::min(buffer.len(), AMOUNT - processed);
+                    (length, length)
+                })
+                .unwrap();
+            processed += length;
         }
 
         // tcp:1235: sink data
@@ -227,16 +225,14 @@ fn main() {
             socket.listen(1235).unwrap();
         }
 
-        if socket.can_recv() {
-            if processed < AMOUNT {
-                let length = socket
-                    .recv(|buffer| {
-                        let length = cmp::min(buffer.len(), AMOUNT - processed);
-                        (length, length)
-                    })
-                    .unwrap();
-                processed += length;
-            }
+        if socket.can_recv() && processed < AMOUNT {
+            let length = socket
+                .recv(|buffer| {
+                    let length = cmp::min(buffer.len(), AMOUNT - processed);
+                    (length, length)
+                })
+                .unwrap();
+            processed += length;
         }
 
         match iface.poll_at(timestamp) {

--- a/examples/sixlowpan_benchmark.rs
+++ b/examples/sixlowpan_benchmark.rs
@@ -1,6 +1,7 @@
 //! 6lowpan benchmark exmaple
 //!
-//! This example is designed to run using the Linux ieee802154/6lowpan support,
+//! This example runs a simple TCP throughput benchmark using the 6lowpan implementation in smoltcp
+//! It is designed to run using the Linux ieee802154/6lowpan support,
 //! using mac802154_hwsim.
 //!
 //! mac802154_hwsim allows you to create multiple "virtual" radios and specify
@@ -11,9 +12,13 @@
 //!
 //! We'll configure Linux to speak 6lowpan on `wpan0`, and leave `wpan1`
 //! unconfigured so smoltcp can use it with a raw socket.
+//! 
+//! 
+//! 
+//! 
 //!
 //! # Setup
-//!
+//!    
 //!     modprobe mac802154_hwsim
 //!
 //!     ip link set wpan0 down
@@ -25,15 +30,11 @@
 //!     ip link set wpan1 up
 //!     ip link set lowpan0 up
 //!
+//!
 //! # Running
 //!
-//! Run it with `sudo ./target/debug/examples/sixlowpan`.
-//!
-//! You can set wireshark to sniff on interface `wpan0` to see the packets.
-//!
-//! Ping it with `ping fe80::180b:4242:4242:4242%lowpan0`.
-//!
-//! Speak UDP with `nc -uv fe80::180b:4242:4242:4242%lowpan0 6969`.
+//! Compile with `cargo build --release --example sixlowpan_benchmark`
+//! Run it with `sudo ./target/release/examples/sixlowpan_benchmark [reader|writer]`.
 //!
 //! # Teardown
 //!
@@ -66,7 +67,7 @@ use std::fs;
 
 fn if_nametoindex(ifname: &str) -> u32 {
     let contents = fs::read_to_string(format!("/sys/devices/virtual/net/{}/ifindex", ifname))
-        .expect("couldn't read interface from \"/sys/devices/virtual/net")
+        .expect("couldn't read interface from \"/sys/devices/virtual/net\"")
         .replace("\n", "");
     contents.parse::<u32>().unwrap()
 }

--- a/examples/sixlowpan_benchmark.rs
+++ b/examples/sixlowpan_benchmark.rs
@@ -53,28 +53,22 @@ use smoltcp::socket::{TcpSocket, TcpSocketBuffer};
 use smoltcp::storage::RingBuffer;
 use smoltcp::wire::{Ieee802154Pan, IpAddress, IpCidr};
 
-
-
 //For benchmark
 use smoltcp::time::{Duration, Instant};
-use std::thread;
 use std::cmp;
-use std::net::TcpStream;
-use std::net::{SocketAddrV6};
 use std::io::{Read, Write};
+use std::net::SocketAddrV6;
+use std::net::TcpStream;
 use std::sync::atomic::{AtomicBool, Ordering};
-
-
+use std::thread;
 
 use std::fs;
-
 
 fn if_nametoindex(ifname: &str) -> u32 {
     let contents = fs::read_to_string(format!("/sys/devices/virtual/net/{}/ifindex",ifname))
         .expect(format!("Something went wrong trying to get IF-index of lowpan0, does \"/sys/devices/virtual/net/{}/ifindex\" exist?", ifname).as_str())
         .replace("\n", "");
     contents.parse::<u32>().unwrap()
-
 }
 
 const AMOUNT: usize = 100_000_000;
@@ -84,8 +78,7 @@ enum Client {
     Writer,
 }
 
-
-fn client(kind: Client){
+fn client(kind: Client) {
     let port: u16 = match kind {
         Client::Reader => 1234,
         Client::Writer => 1235,
@@ -93,10 +86,14 @@ fn client(kind: Client){
 
     let scope_id = if_nametoindex("lowpan0");
 
-    let socket_addr = SocketAddrV6::new("fe80:0:0:0:180b:4242:4242:4242".parse().unwrap(), port, 0, scope_id);
-    
-    //let socket_addr: SocketAddrV6 = "[fe80:0:0:0:180b:4242:4242:4242]:1234".parse().unwrap();
+    let socket_addr = SocketAddrV6::new(
+        "fe80:0:0:0:180b:4242:4242:4242".parse().unwrap(),
+        port,
+        0,
+        scope_id,
+    );
 
+    //let socket_addr: SocketAddrV6 = "[fe80:0:0:0:180b:4242:4242:4242]:1234".parse().unwrap();
 
     let mut stream = TcpStream::connect(socket_addr).expect("failed to connect TLKAGMKA");
     let mut buffer = vec![0; 1_000_000];
@@ -129,10 +126,9 @@ fn client(kind: Client){
     CLIENT_DONE.store(true, Ordering::SeqCst);
 }
 
-
 static CLIENT_DONE: AtomicBool = AtomicBool::new(false);
 
-fn main(){
+fn main() {
     #[cfg(feature = "log")]
     utils::setup_logging("info");
 
@@ -140,14 +136,12 @@ fn main(){
     utils::add_middleware_options(&mut opts, &mut free);
     free.push("MODE");
 
-
     let mut matches = utils::parse_options(&opts, free);
 
     let device = RawSocket::new("wpan1", Medium::Ieee802154).unwrap();
 
     let fd = device.as_raw_fd();
     let device = utils::parse_middleware_options(&mut matches, device, /*loopback=*/ false);
-
 
     let mode = match matches.free[0].as_ref() {
         "reader" => Client::Reader,
@@ -195,10 +189,7 @@ fn main(){
     let tcp1_handle = iface.add_socket(tcp1_socket);
     let tcp2_handle = iface.add_socket(tcp2_socket);
 
-
-
     let default_timeout = Some(Duration::from_millis(1000));
-    
 
     thread::spawn(move || client(mode));
     let mut processed = 0;


### PR DESCRIPTION
Added a TCP throughput benchmark example for sixlowpan with fragmentation, based on the existing benchmark example

compile with: `cargo build --release --example sixlowpan_benchmark`
run with `sudo ./target/release/examples/sixlowpan_benchmark [reader|writer]`

PS:
My apologies for earlier closed pull requests with wrong changes being included in them